### PR TITLE
fix: #1799: replace > with >= in device version note to prevent CMD redirect conflict on Windows

### DIFF
--- a/lib/classes/device_installer.py
+++ b/lib/classes/device_installer.py
@@ -612,7 +612,7 @@ class DeviceInstaller():
                                 else:
                                     tag = f'rocm{matched[0]}.{matched[1]}.{matched[2]}' if matched[2] else f'rocm{matched[0]}.{matched[1]}'
                         if cmp == 1:
-                            msg = f'ROCm {version_str} > tested max {max_ver}; using {tag} torch build.' if tag else f'ROCm {version_str} detected but no compatible torch build for this OS.'
+                            msg = f'ROCm {version_str} >= tested max {max_ver}; using {tag} torch build.' if tag else f'ROCm {version_str} detected but no compatible torch build for this OS.'
                         elif not tag:
                             msg = f'ROCm {version_str} detected but no compatible torch build for this OS.'
                 else:
@@ -765,7 +765,7 @@ class DeviceInstaller():
                         name = devices['CUDA']['proc']
                         if cmp == 1:
                             tag = f'cu{max_tuple[0]}{max_tuple[1]}'
-                            msg = f'CUDA {version} > tested max {max_ver}; using cu{max_tuple[0]}{max_tuple[1]} torch build.'
+                            msg = f'CUDA {version} >= tested max {max_ver}; using cu{max_tuple[0]}{max_tuple[1]} torch build.'
                         else:
                             tag = f'cu{current[0]}{current[1]}'  # still index 0/1, ignore patch
                 else:
@@ -809,7 +809,7 @@ class DeviceInstaller():
                             name = devices['CUDA']['proc']
                             if cmp == 1:
                                 tag = f'cu{max_tuple[0]}{max_tuple[1]}'
-                                msg = f'CUDA {smi_version} (from nvidia-smi) > tested max {max_ver}; using cu{max_tuple[0]}{max_tuple[1]} torch build.'
+                                msg = f'CUDA {smi_version} (from nvidia-smi) >= tested max {max_ver}; using cu{max_tuple[0]}{max_tuple[1]} torch build.'
                             else:
                                 tag = f'cu{current[0]}{current[1]}'
                                 msg = f'CUDA {smi_version} detected via nvidia-smi (driver-only).'
@@ -931,7 +931,7 @@ class DeviceInstaller():
                         name = devices['XPU']['proc']
                         tag = devices['XPU']['proc']
                         if cmp == 1:
-                            msg = f'XPU oneAPI {version} > tested max {max_ver}; using default xpu torch build.'
+                            msg = f'XPU oneAPI {version} >= tested max {max_ver}; using default xpu torch build.'
                 elif xpu_device_count > 0:
                     msg = 'Intel GPU detected but oneAPI toolkit version file not found.'
                 else:


### PR DESCRIPTION
On Windows, the JSON note field containing e.g. 'CUDA 13.1 > tested max 13.0'
is parsed by CMD's for /f loop in check_device_info. The > character is
interpreted as a redirect operator, causing:

    "13.1" kann syntaktisch an dieser Stelle nicht verarbeitet werden.

This breaks the installation on any GPU with a CUDA/ROCm/XPU version
higher than the tested maximum.

Fix: replace > with >= in all version comparison note messages in
device_installer.py. The meaning is preserved (version exceeds tested
max) and >= is safe for CMD parsing.

Affected: CUDA, ROCm, XPU version note messages.
Tested on: RTX 5060, CUDA 13.1, Windows 11.