### PR TITLE
fix #8: remove leading space in dot replacement to prevent TTS distortion at sentence end

### DIFF
--- a/lib/classes/tts_engines/xtts.py
+++ b/lib/classes/tts_engines/xtts.py
@@ -117,7 +117,7 @@ class XTTSv2(TTSUtils, TTSRegistry, name='xtts'):
                         trim_audio_buffer = 0.006
                         if part.endswith("'"):
                             part = part[:-1]
-                        part = part.replace('.', ' ;\n')
+                        part = part.replace('.', ';\n')
                         if self.params['current_voice'] is not None and self.params['current_voice'] in self.params['latent_embedding'].keys():
                             self.params['gpt_cond_latent'], self.params['speaker_embedding'] = self.params['latent_embedding'][self.params['current_voice']]
                         else:


### PR DESCRIPTION
fixes #8:

part.replace('.', ' ;\n') causes the TTS model to generate an audible distortion at the end of sentences, analogous to the [break] token distortion at sentence start (#1792).

The leading space before ';' is unnecessary and causes the model to render an artifact before the sentence boundary marker.

Fix: replace with ';\n' (no leading space).