### PR TITLE
fix #7: move [break]/[pause] token to end of preceding sentence after hard punctuation split

### DIFF
--- a/lib/core.py
+++ b/lib/core.py
@@ -1471,7 +1471,7 @@ def get_sentences(session_id:str, text:str)->list|None:
 
         # PASS 1 — hard punctuation
         hard_pattern = re.compile(
-            rf"(.*?(?:{'|'.join(map(re.escape, punctuation_split_hard_set))}))(?=\s|$)",
+            rf"(.*?(?:{'|'.join(map(re.escape, punctuation_split_hard_set))})[\uE000-\uF8FF]*)(?=\s|$)",
             re.DOTALL
         )
         hard_list = split_inclusive(text, hard_pattern)
@@ -1575,7 +1575,7 @@ def get_sentences(session_id:str, text:str)->list|None:
                     break
                 if final_list:
                     prev = final_list[-1]
-                    if clean_len(prev) + cur_len <= max_chars:
+                    if clean_len(prev) + cur_len <= max_chars and not (prev and ord(prev[-1]) >= sml_escape_tag):
                         final_list[-1] = prev.rstrip() + ' ' + cur.lstrip()
                         i = j
                         continue
@@ -2124,7 +2124,7 @@ def normalize_text(text:str, lang:str, lang_iso1:str, tts_engine:str)->str:
     # Escape special characters in the punctuation list for regex
     pattern = '|'.join(map(re.escape, punctuation_split_hard_set))
     # Reduce multiple consecutive punctuations hard
-    text = re.sub(rf'(\s*({pattern})\s*)+', r'\2 ', text).strip()
+    text = re.sub(rf'(\s*({pattern})\s*)([\uE000-\uF8FF])?', lambda m: m.group(2) + (m.group(3) or '') + ' ' if m.group(2) else m.group(0), text).strip()
     # Escape special characters in the punctuation list for regex
     pattern = '|'.join(map(re.escape, punctuation_split_soft_set))
     # Reduce multiple consecutive punctuations soft


### PR DESCRIPTION
Follow-up DrewThomasson#1791

normalize_text() inserts a trailing space after hard punctuation on the escaped text, placing it between the punctuation and the SML escape char (e.g. "packen. \uE000" instead of "packen.\uE000 "). This causes the token to appear at the start of the next sentence, producing incorrect pause timing and misleading progress output.

Fix 1 - normalize_text(): place the space after the SML escape char.

Fix 2 - get_sentences() PASS 1: consume trailing SML escape chars in hard_pattern so they stay with the preceding sentence.

Fix 3 - get_sentences() PASS 4: don't merge a short sentence backward across a paragraph boundary (sentence ending with SML escape char).