### PR TITLE
 fixes thekk1#15: preserve paragraph [break] tags removed by break_between_alnum_re

### DIFF
--- a/lib/core.py
+++ b/lib/core.py
@@ -1469,8 +1469,8 @@ def filter_blocks(session_id:str, idx:int, doc:EpubHtml, stanza_nlp:Pipeline, is
             break_token = re.escape(sml_token('break'))
             strip_break_spaces_re = re.compile(rf'\s*{break_token}\s*')
             break_between_alnum_re = re.compile(rf'(?<=[\w]){break_token}(?=[\w])', flags=re.UNICODE)
-            text = strip_break_spaces_re.sub(sml_token('break'), text)
             text = break_between_alnum_re.sub(' ', text)
+            text = strip_break_spaces_re.sub(sml_token('break'), text)
             # escape all SML tags to not be touched by any text treatment
             text, sml_blocks = escape_sml(text)
             if sml_blocks and sml_blocks[0] == '[break]':


### PR DESCRIPTION
 fixes thekk1#15:
 
Swap the order of strip_break_spaces_re and break_between_alnum_re in filter_blocks(). Previously, strip_break_spaces_re removed whitespace around all [break] tags first, making them indistinguishable from spurious inline breaks, which break_between_alnum_re then deleted.

With the new order, break_between_alnum_re runs first and only matches [break] tags that have no surrounding whitespace (i.e. genuine inline breaks from span/inline tags). Legitimate paragraph breaks, which always carry surrounding whitespace from the clean_list join, are left intact for strip_break_spaces_re to normalize.

Fixes chapter titles running into body text without pause, e.g.: before: 'Kapitel eins Ich glaube nicht...' after:  'Kapitel eins[pause] Ich glaube nicht...'